### PR TITLE
Potential fix for code scanning alert no. 22: Information exposure through an exception

### DIFF
--- a/blueprints/dashboard/routes.py
+++ b/blueprints/dashboard/routes.py
@@ -159,13 +159,14 @@ def upload() -> Union[str, 'Response']:
             os.makedirs(upload_dir, exist_ok=True)
             logger.info(f"Created missing upload directory: {upload_dir}")
         except Exception as e:
+            logger.error(f"Error creating upload directory: {str(e)}", exc_info=True)
             if is_ajax:
                 return jsonify({
                     'success': False,
-                    'message': f"Could not create upload directory: {str(e)}"
+                    'message': "Could not create upload directory. Please contact the administrator."
                 }), 500
             else:
-                flash(f"Upload system error: {str(e)}", 'error')
+                flash("Upload system error. Please contact the administrator.", 'error')
                 return redirect(url_for('dashboard.records'))
     
     # Check write permissions with a quick test
@@ -175,15 +176,14 @@ def upload() -> Union[str, 'Response']:
             f.write('test')
         os.remove(test_file)
     except Exception as e:
-        error_msg = f"Upload directory is not writable: {str(e)}"
-        logger.error(error_msg)
+        logger.error(f"Upload directory is not writable: {str(e)}", exc_info=True)
         if is_ajax:
             return jsonify({
                 'success': False,
-                'message': "Cannot write to upload directory. Please contact administrator."
+                'message': "Cannot write to upload directory. Please contact the administrator."
             }), 500
         else:
-            flash("Upload system error: Permission denied", 'error')
+            flash("Upload system error. Please contact the administrator.", 'error')
             return redirect(url_for('dashboard.records'))
     
     if request.method == 'POST':


### PR DESCRIPTION
Potential fix for [https://github.com/charan-143/medical/security/code-scanning/22](https://github.com/charan-143/medical/security/code-scanning/22)

To fix the issue, we should replace the detailed error message in the JSON response with a generic error message. The detailed exception information should instead be logged on the server for debugging purposes. This ensures that sensitive information is not exposed to external users while still allowing developers to diagnose issues.

- Replace the use of `str(e)` in the JSON response with a generic error message.
- Log the detailed exception information using the `logger` object.
- Ensure that the fix is applied consistently across all similar cases in the function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
