### PR TITLE
Potential fix for code scanning alert no. 11: Client-side cross-site scripting

### DIFF
--- a/static/js/pdf_processor.js
+++ b/static/js/pdf_processor.js
@@ -9,6 +9,24 @@
  */
 
 class PDFProcessor {
+
+    /**
+     * Utility function to escape HTML special characters
+     * @param {string} str - The string to escape
+     * @returns {string} - The escaped string
+     */
+    escapeHTML(str) {
+        return str.replace(/[&<>"']/g, (char) => {
+            const escapeMap = {
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                '"': '&quot;',
+                "'": '&#39;'
+            };
+            return escapeMap[char];
+        });
+    }
     constructor() {
         // Configuration
         this.config = {
@@ -124,7 +142,7 @@ class PDFProcessor {
         processingContainer.innerHTML = `
             <div class="pdf-processing-prompt text-center p-4">
                 <p>Would you like to analyze this PDF for images using Gemini 2.0 Flash?</p>
-                <button id="process-pdf-btn" class="btn btn-primary" data-document-id="${documentId}">
+                <button id="process-pdf-btn" class="btn btn-primary" data-document-id="${this.escapeHTML(documentId)}">
                     <i class="fas fa-brain"></i> Analyze PDF Images
                 </button>
             </div>


### PR DESCRIPTION
Potential fix for [https://github.com/charan-143/medical/security/code-scanning/11](https://github.com/charan-143/medical/security/code-scanning/11)

To fix the issue, we need to ensure that the `documentId` value is properly sanitized or encoded before being inserted into the HTML. The best approach is to use a contextual output encoding function, such as `textContent` for text nodes or a library like `DOMPurify` for sanitizing HTML. In this case, since `documentId` is used within a template literal, we can escape it using a utility function that encodes special characters (e.g., `<`, `>`, `&`, `"`).

Steps to fix:
1. Create a utility function to escape HTML special characters.
2. Use this function to sanitize `documentId` before embedding it in the HTML on line 124.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
